### PR TITLE
Some additions, fixes and modifications

### DIFF
--- a/catppuccin.user.css
+++ b/catppuccin.user.css
@@ -9,6 +9,8 @@
 
 
 @var select theme "Theme" ["Latte", "Frappe", "Macchiato", "Mocha*"]
+
+@var checkbox navbar-color "Use dark navbar-color" 0
 ==/UserStyle== */
 
 @-moz-document domain("codeberg.org") {
@@ -232,13 +234,24 @@
         color: $text;
         
     }
-   
+  
+    div#navbar.ui.container {
+        background-color: $blue !important;
+        color: $base !important;
+    }
+    
+    if navbar-color {
+        div#navbar.ui.container {
+            background-color: $mantle !important;
+            color: $text !important;
+        }
+    }
+
     th,
     textarea,
     h4.ui.top.attached.error.header,
     div.ui.red.message,
     div.ui.segment.sub-menu.repository-menu,
-    div#navbar.ui.container,
     nav.navbar,
     div.sidebar,
     div.sidebar-menu,

--- a/catppuccin.user.css
+++ b/catppuccin.user.css
@@ -233,7 +233,161 @@
         
     }
    
+    th,
+    textarea,
+    h4.ui.top.attached.error.header,
+    div.ui.red.message,
+    div.ui.segment.sub-menu.repository-menu,
+    div#navbar.ui.container,
+    nav.navbar,
+    div.sidebar,
+    div.sidebar-menu,
+    div.card,
+    div.menu.left.transition.visible,
+    div.menu.user-menu.left.transition.visible,
+    a.item.active
+    input,
+    div.ui.dropdown.icon.button,
+    div.ui.borderless.pagination.menu.narrow,
+    span.name,
+    blockquote.alert {
+        background-color: $mantle !important;
+        color: $text !important;
+        transition: 0.5s;
+    }
     
+    div.extra.content.word-break,
+    td.name,
+    td.message,
+    td.text {
+        border-color: $surface1 !important;
+    }
+    
+    div.ui.top.attached.header.clearing.segment.pr.commit-header,
+    footer,
+    h1,
+    h3,
+    h4 {
+        background-color: $mantle !important;
+    }
+    
+    div.ui.compact.tiny.menu,
+    div.ui.secondary.pointing.tabular.top.attached.borderless.menu.stackable.new-menu.navbar,
+    div.ui.attached.segment,
+    div.ui.borderless.pagination.menu,
+    div.ui.two.item.tabable.menu,
+    div.ui.secondary.tiny.pointing.borderless.menu.center.grid.repos-filter,
+    div.header-wrapper,
+    div.ui.attached.segment.df.ac.sb.py-2.commit-header-row.fw,
+    div.file-view.markup.markdown,
+    div.ui.attached.segment.repos-search,
+    div.ui.attached.table.segment.rounded-bottom {
+        background-color: $base !important;
+    }
+    
+    span.ui.grey.label.ml-3,
+    div.ui.circular.mini.grey.label,
+    div.divider,
+    button.btn.btn-primary,
+    div.ui.language.bottom.floating.slide.up.dropdown.link.item.button {
+        background-color: $surface0 !important;
+    }
+    
+    tr {
+        background-color: $base !important;
+    }
+    
+    .blob-excerpt.lines-code {
+        background-color: $mantle !important;
+    }
+    .chroma.lines-code {
+        background-color: transparent !important;
+    }
+    .add-code {
+        background-color: alpha($green, 0.1) !important;
+    }
+    .added-code {
+        background-color: alpha($green, 0.15) !important;
+        color: $text !important;
+    }
+    .del-code {
+        background-color: alpha($red, 0.1) !important;
+    }
+    .removed-code {
+        background-color: alpha($red, 0.15) !important;
+        color: $text !important;
+    }
+    code.code-inner {
+        color: $overlay1 !important;
+    }
+    tr.tag-code.nl-0.ol-0, td.lines-num, td.lines-type-marker {
+        background-color: alpha($blue, 0.1) !important;
+    }
+    
+    kbd,
+    code {
+        background-color: transparent !important;
+        color: $text !important;
+    }
+    
+    span.c1 {
+        color: $overlay1 !important;
+    }
+    span.s1 {
+        color: $peach !important;
+    }
+    span.token.string,
+    span.s2 {
+        color: $green !important;
+    }
+    span.n {
+        color: $text !important;
+    }
+    span.o,
+    span.kc,
+    span.kd,
+    span.kr {
+        color: $red !important;
+    }
+    span.nf {
+        color: $blue !important;
+    }
+    span.token.function,
+    span.mi {
+        color: $teal !important;
+    }
+        
+    nav.navbar {
+        border: none !important;
+    }
+    
+    pre {
+        background-color: $mantle !important;
+        border-color: $blue !important;
+    }
+    
+    a.ui.primary.sha.label,
+    span.ui.primary.sha.label {
+        background-color: $mantle !important;
+    }
+    
+    h1,
+    a,
+    a.header-anchor,
+    a.item {
+        background-color: transparent !important;
+        color: $blue !important;
+        transition: 0.5s;
+    }
+    
+    a:hover,
+    a.item:hover,
+    span.name:hover {
+        background-color: transparent !important;
+        color: $green !important;
+        transition: 0.5s;
+    }
+        
     .ui.table {
         color: $text;
     }
@@ -272,7 +426,7 @@
     }
     
     .following.bar #navbar {
-        background-color: $blue!important;
+        background-color: $blue !important;
         
     }
     
@@ -362,4 +516,3 @@
         
     }
 }
-


### PR DESCRIPTION
Following is a brief summary of what I did:

Firstly, I fixed the sidebar on the docs.codeberg.org page which had a light background alien from the rest of the page and was irritating me a lot.

Secondly, I fixed the colouring on the commit code page. I took Github's commit code page as a reference. However it seemed like there is a discrepancy in elements on that page hence the entire first 2 columns inherit the colour of the tag row. I could not see any bypass solution so I tried to minimize it and look as consistent as possible.

Thirdly, I fixed the colours of a few elements which were not coloured across the website. On some elements, I have chosen the darker mantle colour instead of base to make elements like nav bars or text areas more distinct which is different from the original style. Revert it to base otherwise.

Fourthly, I had originally coloured the main nav bar to mantle however I saw the other pull request where a discussion on the same occured and therefore I added an option between a mantle navbar and a blue navbar (by default).

Fifthly, I have added fade transitions on hovering over links from Blue to Green and back. I personally follow this pattern on websites I style on my end however if it is against the Catppuccin Styling Guide, considering someone mentioned that the goal is only to recolour, feel free to remove it. 

Sixth and lastly, the code is a mess. It is not ordered properly and some elements mentioned there may not be necessary and it can surely be cleaned further however I have a constraint on time so I could not test it any further or add comments to make things clearer.